### PR TITLE
Fix People Download bug

### DIFF
--- a/src/pyopenstates/downloads.py
+++ b/src/pyopenstates/downloads.py
@@ -66,7 +66,7 @@ def _download_zip(url: str) -> pathlib.Path:
 
 def _load_session_data(state: str, session: str, file_type: FileType) -> str:
     if file_type == FileType.People:
-        return requests.get("https://data.openstates.org/people/current/ak.csv").text
+        return requests.get(f"https://data.openstates.org/people/current/{state}.csv").text
     url = _get_download_url(state, session)
     zip_path = _download_zip(url)
     with zipfile.ZipFile(zip_path) as zf:


### PR DESCRIPTION
I was thinking of adding  something like `assert "Montgomery, AL" in data[0].value()` to test but it happens that there can be blank `capital_address` too.

Also looks like this fails on API request, I am not sure if and where to add that key here. feel free to make the change directly on `main` if this is a pain